### PR TITLE
Updated file formatting to run in unix

### DIFF
--- a/rootfs/etc/cont-init.d/10-homeseer-install
+++ b/rootfs/etc/cont-init.d/10-homeseer-install
@@ -1,11 +1,8 @@
 #!/usr/bin/with-contenv sh
-
 # Install HomeSeer if container is started for the first time
 if [ -e /DO_INSTALL ]
-
 then
     echo "HomeSeer (re)install/update required at container first run. Installing at /HomeSeer..."
-
     wget -O /homeseer.tgz "http://homeseer.com/updates4/linux_$HOMESEER_VERSION.tar.gz"
     tar -xzo -C / -f /homeseer.tgz
     rm -f /homeseer.tgz
@@ -13,5 +10,4 @@ then
 
 else
     echo "HomeSeer already installed, not (re)installing/updating..."
-
 fi

--- a/rootfs/etc/cont-init.d/20-dbus-avahi
+++ b/rootfs/etc/cont-init.d/20-dbus-avahi
@@ -1,9 +1,7 @@
 #!/usr/bin/with-contenv sh
-
 # make folders
 mkdir -p /var/run/dbus
 mkdir -p /var/run/avahi-daemon
-
 # delete existing pid if found
 [ -e /var/run/dbus.pid ] && rm -f /var/run/dbus.pid
 [ -e /var/run/dbus/pid ] && rm -f /var/run/dbus/pid

--- a/rootfs/etc/services.d/avahi/run
+++ b/rootfs/etc/services.d/avahi/run
@@ -1,8 +1,6 @@
 #!/usr/bin/with-contenv sh
-
 until [ -e /var/run/dbus/system_bus_socket ]; do
-  sleep 1s
+	sleep 1s
 done
-
 echo "Starting Avahi daemon..."
 exec avahi-daemon --no-chroot -f /etc/avahi/avahi-daemon.conf

--- a/rootfs/etc/services.d/dbus/run
+++ b/rootfs/etc/services.d/dbus/run
@@ -1,4 +1,3 @@
 #!/usr/bin/with-contenv sh
-
 echo "Starting dbus-daemon..."
 exec dbus-daemon --system --nofork

--- a/rootfs/etc/services.d/homeseer/run
+++ b/rootfs/etc/services.d/homeseer/run
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv sh
-
 # wait for services to come up
 sleep 2
 


### PR DESCRIPTION
Dockerhub no longer auto builds repos on update.  You either have to pay to get a subscription or build the image locally and push it to dockerhub.  I was able to get the image to build and I've tested pushing it to my dockerhub **tin13/homeseer4** and pulling/deploying it to my unraid instance that was running on the e1ite/docker-homeseer4 image.  